### PR TITLE
feat: preloading sync data

### DIFF
--- a/src/Codibre.EnumerableExtensions.Branching/BranchRunOptions.cs
+++ b/src/Codibre.EnumerableExtensions.Branching/BranchRunOptions.cs
@@ -4,5 +4,6 @@ namespace Codibre.EnumerableExtensions.Branching;
 public readonly struct BranchRunOptions(int limit)
 {
     public static readonly BranchRunOptions Default = new(ushort.MaxValue / 4);
+    public static readonly BranchRunOptions Yielder = new(1);
     public int Limit => limit;
 }

--- a/src/Codibre.EnumerableExtensions.Branching/BranchingBuilder.cs
+++ b/src/Codibre.EnumerableExtensions.Branching/BranchingBuilder.cs
@@ -11,9 +11,8 @@ public sealed class BranchingBuilder<T>(IEnumerable<T> source) : BaseBranchingBu
     internal override LinkedNode<T> Iterate(BranchRunOptions options)
     {
         var enumerator = source.GetEnumerator();
-        return LinkedNode<T>.Root(
-            (c) => new(enumerator.MoveNext() ? new LinkedNode<T>(enumerator.Current, c) : null),
-            options
-        );
+        var getNext = (IBranchContext<T> c) => ValueTask.FromResult(LinkedNode<T>.New(enumerator, options, c));
+        BranchContext<T> context = new(getNext, BranchRunOptions.Yielder);
+        return LinkedNode<T>.Root(enumerator, options, context);
     }
 }

--- a/src/Codibre.EnumerableExtensions.Branching/Internal/LinkedNode.cs
+++ b/src/Codibre.EnumerableExtensions.Branching/Internal/LinkedNode.cs
@@ -1,8 +1,34 @@
 ﻿namespace Codibre.EnumerableExtensions.Branching.Internal;
 
-internal sealed record LinkedNode<T>(T Value, IBranchContext<T> Context)
+internal sealed record LinkedNode<T>
 {
-    public Lazy<ValueTask<LinkedNode<T>?>> Next { get; } = new(Context.FillNext, LazyThreadSafetyMode.ExecutionAndPublication);
+    public T Value { get; }
+    public Lazy<ValueTask<LinkedNode<T>?>>? Next { get; private set; }
+
+    public LinkedNode(T value, IBranchContext<T> context)
+    {
+        Value = value;
+        Next = new(context.FillNext, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    private LinkedNode(T value) => Value = value;
+
+    public static LinkedNode<T>? New(IEnumerator<T> source, BranchRunOptions options, IBranchContext<T> context)
+    {
+        if (!source.MoveNext()) return null;
+        var preload = options.Limit;
+        LinkedNode<T> root = new(source.Current);
+        var node = root;
+        while (preload-- > 0 && source.MoveNext()) node = (node.Next = new(ValueTask.FromResult<LinkedNode<T>?>(new(source.Current)))).Value.Result!;
+        node.Next = new(context.FillNext, LazyThreadSafetyMode.ExecutionAndPublication);
+        return root;
+    }
+
+    public static LinkedNode<T> Root(IEnumerator<T> source, BranchRunOptions options, IBranchContext<T> context)
+        => new(default(T)!)
+        {
+            Next = new(ValueTask.FromResult(New(source, options, context)))
+        };
 
     public static LinkedNode<T> Root(Func<IBranchContext<T>, ValueTask<LinkedNode<T>?>> getNext, BranchRunOptions options)
     {

--- a/test/Codibre.EnumerableExtensions.Branching.Test/EnumerableExtensionsTest.cs
+++ b/test/Codibre.EnumerableExtensions.Branching.Test/EnumerableExtensionsTest.cs
@@ -22,7 +22,7 @@ public class BranchingBuilderTest()
             .Add(x => x.ToArrayAsync(), out var a)
             .Add(x => x.ToArrayAsync(), out var b)
             .Add(x => x.ToArrayAsync(), out var c)
-            .Run();
+            .Run(new(2));
 
         // Assert
         a.Result.Should().BeEquivalentTo(enumerable.ToArray());


### PR DESCRIPTION
Preloading sync data boosts performance
to the vanilla level, making Branch
operation much more performant